### PR TITLE
CLEAN CHAT AND NOTIF | ADD CANCEL AND REJECT FRINED BUTTON | UPDATING USER DATA AFTER GAME

### DIFF
--- a/srcs/api/apps/pongue/consumers/game.py
+++ b/srcs/api/apps/pongue/consumers/game.py
@@ -191,14 +191,22 @@ class GameConsumer(AsyncWebsocketConsumer):
                 winner=User.objects.get(id=winner.player_id)
             )
 
-            MatchParticipant.objects.create(
+            pl1 = MatchParticipant.objects.create(
                 user=User.objects.get(id=self.pong_game.player1.player_id),
                 score=self.pong_game.player1.score,
                 match=match_played
             )
 
-            MatchParticipant.objects.create(
+            pl2 = MatchParticipant.objects.create(
                 user=User.objects.get(id=self.pong_game.player2.player_id),
                 score=self.pong_game.player2.score,
                 match=match_played
             )
+            if pl1.score > pl2.score:
+                pl1.user.wins += 1
+                pl2.user.loses += 1
+            else:
+                pl2.user.wins += 1
+                pl1.user.loses += 1
+            pl1.user.save()
+            pl2.user.save()

--- a/srcs/api/apps/users/apps.py
+++ b/srcs/api/apps/users/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+class NotificationsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'apps.users'
+    def ready(self):
+        import apps.users.signals

--- a/srcs/api/apps/users/signals.py
+++ b/srcs/api/apps/users/signals.py
@@ -1,0 +1,19 @@
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from .models import Notification, Message
+from apps.utils import send_real_time_notif
+from .serializers import NotificationSerializer
+
+@receiver(post_save, sender=Message)
+def notify_message(sender, instance, created, **kwargs):
+    if created:
+        connection = instance.connection
+        recipient = connection.get_other_user(instance.sender)
+        notif = Notification.objects.create(
+            user=recipient,
+            notification_type=Notification.NOTIFICATION_TYPES['messages'],
+            message=f'New message from {instance.sender.username}'
+        )
+        data = NotificationSerializer(notif)
+        send_real_time_notif(recipient.id, data.data)

--- a/srcs/api/apps/users/views/notification.py
+++ b/srcs/api/apps/users/views/notification.py
@@ -6,4 +6,10 @@ class NotificationListView(generics.ListAPIView):
     serializer_class = NotificationSerializer
     
     def get_queryset(self):
-        return Notification.get_notif(self.request.user)
+        notifs = Notification.get_notif(self.request.user)
+        for notif in notifs:
+            if notif.read == True:
+                break
+            notif.read = True
+            notif.save()
+        return notifs

--- a/srcs/api/apps/utils/utils.py
+++ b/srcs/api/apps/utils/utils.py
@@ -82,9 +82,10 @@ def send_real_time_notif(user_id, data):
         event_type (str): Event type to send.
         data (dict): Data to send.
     """
+    data['type'] = 'notification'
     channel_layer = get_channel_layer()
     async_to_sync(channel_layer.group_send)(
-        f"user_notif_{user_id}",
+        f"user_{user_id}",
         {
             "type": 'send_notification',
             "data": data,

--- a/srcs/api/config/asgi.py
+++ b/srcs/api/config/asgi.py
@@ -32,8 +32,7 @@ application = ProtocolTypeRouter(
                 URLRouter(
                     [
                         re_path('ws/game/$', GameConsumer.as_asgi()),
-                        re_path(r'ws/chat/$', ChatConsumer.as_asgi(), {'type': 'chat'}),
-                        re_path(r"ws/notifications/(?P<user_id>\d+)/$", ChatConsumer.as_asgi(), {'type': 'notifications'}),
+                        re_path(r'ws/chat/$', ChatConsumer.as_asgi()),
                         re_path(r'', unmatched_route), # catch all unmatched routes
                     ]
                 ),

--- a/srcs/frontend/src/app/auth/signup/page.tsx
+++ b/srcs/frontend/src/app/auth/signup/page.tsx
@@ -77,11 +77,11 @@ export default function SignUpPage() {
     }
   }
 
-  const handleSignUp = async () => {
+  const handleSignUp = async (index: number) => {
     try {
       const res = await axios.get('http://localhost:8000/api/auth/social/providers/')
-      console.log(res.data.providers[1].provider_url);
-      router.push(res.data.providers[1].provider_url);
+      console.log(res.data.providers[index].provider_url);
+      router.push(res.data.providers[index].provider_url);
     } catch (err: any) {
       console.error('Error:', err.response )
       

--- a/srcs/frontend/src/app/users/home/page.tsx
+++ b/srcs/frontend/src/app/users/home/page.tsx
@@ -15,36 +15,7 @@ const Home = () => {
 
   useEffect(() => {
     updateCurrentPage("home");
-    const fetchData = async () => {
-      try {
-        const res = await axios.get("http://localhost:8000/api/users/me/", { withCredentials: true });
-        updateUserData({
-          id: res.data.id,
-          otp_uri: res.data.otp_uri,
-          last_login: res.data.last_login,
-          is_superuser: res.data.is_superuser,
-          username: res.data.username,
-          first_name: res.data.first_name,
-          last_name: res.data.last_name,
-          email: res.data.email,
-          is_staff: res.data.is_staff,
-          is_active: res.data.is_active,
-          date_joined: res.data.date_joined,
-          two_fa_enabled: res.data.two_fa_enabled,
-          is_online: res.data.is_online,
-          avatar_url: res.data.avatar_url,
-          wins: res.data.wins,
-          loses: res.data.loses,
-          rating: res.data.rating,
-          rank: res.data.rank,
-        })
-      } catch (err: any) {
-        console.log("Error in fetching user data", err);
-      }
-    };
-
-    fetchData();
-  }, [updateCurrentPage, updateUserData]);
+  }, [updateCurrentPage]);
 
   return (
     <div className={classes.home}>

--- a/srcs/frontend/src/app/users/layout.tsx
+++ b/srcs/frontend/src/app/users/layout.tsx
@@ -16,8 +16,8 @@ export default function UsersLayout({
   children: React.ReactNode;
 }) {
   return (
-    <WebSocketProvider>
-      <UserContextProvider>
+    <UserContextProvider>
+      <WebSocketProvider>
 
       <div className="layout-container">
         <div className="verticalNavbarr">
@@ -35,7 +35,7 @@ export default function UsersLayout({
           </div>
         </div>
       </div>
-      </UserContextProvider>
-    </WebSocketProvider>
+      </WebSocketProvider>
+    </UserContextProvider>
   );
 }

--- a/srcs/frontend/src/components/Friends/Friends.tsx
+++ b/srcs/frontend/src/components/Friends/Friends.tsx
@@ -130,6 +130,20 @@ const Friends = () => {
         }
     };
 
+    const handleRejectRequest = async (id: number) => {
+        try {
+            const resp = await axios.delete(`http://localhost:8000/api/users/me/connections/${id}/`, {
+                withCredentials: true,
+            });
+            if (resp.status === 204) {
+                setRequests((prevRequests) => prevRequests.filter((item) => item.id !== id));
+            }
+            console.log("Friend request rejected successfully");
+        } catch (error) {
+            console.error("Error rejecting friend request:", error);
+        }
+    };
+
     const Request = () => (
         <div>
             {requests.map((item) => (
@@ -149,6 +163,12 @@ const Friends = () => {
                             onClick={() => handleAcceptRequest(item.id)}
                         >
                             Accept
+                        </button>
+                        <button
+                            className={`${styles.actionButton} ${styles.blockButton}`}
+                            onClick={() => handleRejectRequest(item.id)}
+                        >
+                            Reject
                         </button>
                     </div>
                 </div>

--- a/srcs/frontend/src/components/FriendsFR/FriendsFR.tsx
+++ b/srcs/frontend/src/components/FriendsFR/FriendsFR.tsx
@@ -42,7 +42,7 @@ const FriendsFR = ({id}) => {
   const confirmCancelRequest = async () => {
     try {
       await axios.delete(
-        `http://localhost:8000/api/users/me/connections/${id}/`,
+        `http://localhost:8000/api/users/me/connections/${searchedUserData.connection.id}/`,
         { withCredentials: true }
       );
       console.log("Friend request cancelled");

--- a/srcs/frontend/src/context/UserContext.tsx
+++ b/srcs/frontend/src/context/UserContext.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { createContext, useContext, useState, ReactNode } from "react";
+import { createContext, useContext, useState, useEffect, ReactNode } from "react";
+import axios from "axios";
 
 // Define a type for the context value
 interface UserContextType {
@@ -82,6 +83,7 @@ interface UserContextProviderProps {
 }
 
 export const UserContextProvider = ({ children }: UserContextProviderProps) => {
+    
     const [currentPage, setCurrentPage] = useState<string>("");
     const [userData, setUserData] = useState<UserDataType>({
         id: null,
@@ -170,5 +172,38 @@ export const useUserContext = () => {
     if (!context) {
         throw new Error("useUserContext must be used within a UserContextProvider");
     }
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const res = await axios.get("http://localhost:8000/api/users/me/", { withCredentials: true });
+                context.updateUserData({
+                    id: res.data.id,
+                    otp_uri: res.data.otp_uri,
+                    last_login: res.data.last_login,
+                    is_superuser: res.data.is_superuser,
+                    username: res.data.username,
+                    first_name: res.data.first_name,
+                    last_name: res.data.last_name,
+                    email: res.data.email,
+                    is_staff: res.data.is_staff,
+                    is_active: res.data.is_active,
+                    date_joined: res.data.date_joined,
+                    two_fa_enabled: res.data.two_fa_enabled,
+                    is_online: res.data.is_online,
+                    avatar_url: res.data.avatar_url,
+                    wins: res.data.wins,
+                    loses: res.data.loses,
+                    rating: res.data.rating,
+                    rank: res.data.rank,
+                })
+            } catch (err: any) {
+                console.log("Error in fetching user data", err);
+            }
+        };
+
+        fetchData();
+    }, [context.updateUserData]);
+
     return context;
 };

--- a/srcs/frontend/src/context/WebSocketContext.tsx
+++ b/srcs/frontend/src/context/WebSocketContext.tsx
@@ -76,7 +76,8 @@ export const WebSocketProvider = ({ children }: { children: React.ReactNode }) =
     if (ws.current?.readyState === WebSocket.OPEN) {
       ws.current.send(JSON.stringify({
         recipient_id: recipientId,
-        message: message
+        message: message,
+        type: 'message',
       }));
     }
   };

--- a/srcs/frontend/src/context/WebSocketContext.tsx
+++ b/srcs/frontend/src/context/WebSocketContext.tsx
@@ -1,5 +1,6 @@
-'use client'
+'use client';
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { UserContext, UserContextProvider } from './UserContext';
 
 interface Message {
   message: string;
@@ -21,7 +22,8 @@ export const WebSocketProvider = ({ children }: { children: React.ReactNode }) =
   const ws = useRef<WebSocket | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [isConnected, setIsConnected] = useState(false);
-
+  const { userData } = useContext(UserContext);
+  
   useEffect(() => {
     const connect = () => {
       const wsUrl = `ws://localhost:8000/ws/chat/`;
@@ -62,7 +64,9 @@ export const WebSocketProvider = ({ children }: { children: React.ReactNode }) =
         setIsConnected(false);
       };
     };
-
+    if (!userData.id) {
+      return;
+    }
     connect();
 
     return () => {
@@ -70,7 +74,7 @@ export const WebSocketProvider = ({ children }: { children: React.ReactNode }) =
         ws.current.close();
       }
     };
-  }, []);
+  }, [userData]);
 
   const sendMessage = (recipientId: number, message: string) => {
     if (ws.current?.readyState === WebSocket.OPEN) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WebSocket Client</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+        #messages {
+            border: 1px solid #ccc;
+            padding: 10px;
+            height: 300px;
+            overflow-y: scroll;
+            background: #f9f9f9;
+        }
+        .message {
+            margin: 5px 0;
+        }
+        .error {
+            color: red;
+        }
+        .success {
+            color: green;
+        }
+        canvas {
+            display: block;
+            margin: 0 auto;
+            background-color: #000;
+        }
+    </style>
+</head>
+<body>
+    <h1>WebSocket Client</h1>
+    <div>
+        <label for="wsUrl">WebSocket URL:</label>
+        <input type="text" id="wsUrl" placeholder="ws://localhost:8000/ws/game/" value="ws://localhost:8000/ws/game/">
+        <button id="connectBtn">Connect</button>
+        <button id="closeBtn">Close</button>
+        <canvas id="game" width="600" height="800"></canvas>
+    </div>
+    <div id="messages"></div>
+
+    <script>
+        const connectBtn = document.getElementById("connectBtn");
+        const closeBtn = document.getElementById("closeBtn");
+        const wsUrlInput = document.getElementById("wsUrl");
+        const messagesDiv = document.getElementById("messages");
+        
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+
+        function drawRec(x, y, w, h, clr) {
+            ctx.fillStyle = clr;
+            ctx.fillRect(x, y, w, h);
+        }
+
+        const net = {
+            x: 0,
+            y: canvas.height / 2 - 1,
+            w: 15,
+            h: 5,
+            clr: 'white'
+        };
+
+        function drawNet() {
+            for (let i = 0; i <= canvas.width; i += 30)
+                drawRec(net.x, net.y+1, net.w, net.h, net.clr);
+        }
+        
+        function drawCrcl(x, y, r) {
+            ctx.fillStyle = 'white';
+            ctx.beginPath();
+            ctx.arc(x, y, r, 0, Math.PI * 2);
+            ctx.closePath();
+            ctx.fill();
+        } 
+        
+        function drawTxt(txt, x, y) {
+            ctx.fillStyle = 'white';
+            ctx.font = '50px Arial';
+            ctx.fillText(txt, x, y);
+        }
+        
+        function drawNet() {
+            for (let i = 0; i <= canvas.height; i += 25)
+                drawRec(net.x, net.y + i, net.w, net.h, net.clr);
+        }
+        
+        function render() {
+            drawRec(0, 0, canvas.width, canvas.height, 'black');
+            drawTxt(opp_paddle.score, canvas.width / 4 * 3, canvas.height / 5);
+            drawTxt(my_paddle.score, canvas.width / 4, canvas.height / 5);
+            drawRec(opp_paddle.x, opp_paddle.y, opp_paddle.w, opp_paddle.h, opp_paddle.clr);
+            drawRec(my_paddle.x, my_paddle.y, my_paddle.w, my_paddle.h, my_paddle.clr);
+            drawCrcl(ball.x, ball.y, ball.r);
+        }
+
+        const my_paddle = {
+            x:0,
+            y:0,
+            w:100,
+            h:20,
+            score:0,
+            clr:'white'
+        };
+
+        const opp_paddle = {
+            x:0,
+            y:0,
+            w:100,
+            h:20,
+            score:0,
+            clr:'white'
+        };
+
+        const ball = {
+            x:0,
+            y:0,
+            r:20,
+            clr:'white'
+        };
+
+        let socket = null;
+
+        function logMessage(message, type = "message") {
+            const msgDiv = document.createElement("div");
+            msgDiv.className = `message ${type}`;
+            msgDiv.textContent = message;
+            messagesDiv.appendChild(msgDiv);
+            messagesDiv.scrollTop = messagesDiv.scrollHeight; // Auto-scroll to the bottom
+        }
+
+        connectBtn.addEventListener("click", () => {
+            const wsUrl = wsUrlInput.value.trim();
+            if (!wsUrl) {
+                logMessage("Please enter a valid WebSocket URL.", "error");
+                return;
+            }
+
+            // Close any existing connection
+            if (socket && socket.readyState === WebSocket.OPEN) {
+                logMessage("Closing existing connection before reconnecting.", "success");
+                socket.close();
+            }
+
+            logMessage(`Connecting to ${wsUrl}...`, "success");
+            socket = new WebSocket(wsUrl);
+
+            socket.onopen = () => {
+                logMessage("Connected successfully!", "success");
+            };
+
+            socket.onmessage = (event) => {
+                data = JSON.parse(event.data);
+                if ('players' in data && 'my_id' in data) {
+                    my_id = data.my_id;
+                    opp_id = data.opp_id;
+                    logMessage(`Message received: ${event.data}`);
+                }
+                opp_paddle.score = data[opp_id].score;
+                opp_paddle.x = data[opp_id].x;
+                opp_paddle.y = data[opp_id].y;
+                my_paddle.x = data[my_id].x;
+                my_paddle.y = data[my_id].y;
+                my_paddle.score = data[my_id].score;
+                ball.x = data.ball.x;
+                ball.y = data.ball.y;
+                render();
+                console.log(data);
+            };
+
+            socket.onerror = (error) => {
+                logMessage(`Error occurred: ${error}`, "error");
+            };
+
+            socket.onclose = (event) => {
+                logMessage(`Connection closed: ${event.reason || "No reason provided"}`, "error");
+            };
+            document.addEventListener("keydown", function(event) {
+                if (event.key === "ArrowLeft") {
+                    socket.send(JSON.stringify({action: "move", player_id: my_id, direction: "left"}));
+                } else if (event.key === "ArrowRight") {
+                    socket.send(JSON.stringify({action: "move", player_id: my_id, direction: "right"}));
+                }
+            });
+        });
+
+        closeBtn.addEventListener("click", () => {
+            if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) {
+                logMessage("Closing WebSocket connection...", "success");
+                socket.close();
+            } else {
+                logMessage("No active WebSocket connection to close.", "error");
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
+ sperated the messages from the notification and using the same group name for both of them.
+ removed the notification websocket endpoint
+ marking the notifications as read when requested from the frontend via API endpoint
+ included the type in the message sent from the frontend
+ added signal to listen if a new message is sent to notify the other user
+ after the match end now it also update the wins and loses of a user
+ fixed canceling the sent freind request and added a button to reject a freind request
+ added a test fro the game consumer and the game logic
+ the websocket wont connect unless the userdata is valid 
+ the user data is initialized in the UserContext instead of the home